### PR TITLE
Remove unneeded call to parent::_construct

### DIFF
--- a/src/LocaleSwitcher.php
+++ b/src/LocaleSwitcher.php
@@ -13,8 +13,6 @@ final class LocaleSwitcher extends Tool
     public function __construct(array $locales = [], $component = null)
     {
         $this->setLocales($locales);
-
-        parent::__construct($component);
     }
 
     public function boot()


### PR DESCRIPTION
This fixes #2 which is a bug that shows when using PHP 8. This removes a call to an invalid parent constructor, which never existed, so never did anything anyway